### PR TITLE
Enable cross-platform shared Python builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        arch: [ x86_64 ]
+        arch: [ x86_64, aarch64 ]
 
     steps:
       - name: Checkout repository
@@ -26,6 +26,9 @@ jobs:
           case "${{ matrix.arch }}" in
             x86_64)
               sudo apt-get install -y gcc g++
+              ;;
+            aarch64)
+              sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
               ;;
           esac
 
@@ -41,7 +44,10 @@ jobs:
           mkdir -p build
           case "${{ matrix.arch }}" in
             x86_64)
-              CFLAGS="-g0" ./configure --build=x86_64-linux-gnu --host=x86_64-linux-gnu --enable-optimizations --enable-ipv6 --disable-shared --enable-static --prefix=$(pwd)/build/x86_64
+              CFLAGS="-g0" ./configure --build=x86_64-linux-gnu --host=x86_64-linux-gnu --enable-optimizations --enable-ipv6 --enable-shared --prefix=$(pwd)/build/x86_64
+              ;;
+            aarch64)
+              CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ CFLAGS="-g0" ./configure --build=x86_64-linux-gnu --host=aarch64-linux-gnu --enable-optimizations --enable-ipv6 --enable-shared --prefix=$(pwd)/build/aarch64
               ;;
           esac
           make -j$(nproc)
@@ -84,8 +90,8 @@ jobs:
       
       - name: Install pip packages
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install markitdown
+          /usr/bin/python3 -m pip install --upgrade pip
+          /usr/bin/python3 -m pip install markitdown
 
       - name: Save built libraries
         run: |

--- a/pkg/markitdown/python_cgo.go
+++ b/pkg/markitdown/python_cgo.go
@@ -2,13 +2,13 @@ package markitdown
 
 /*
 #cgo darwin,arm64 CFLAGS: -I${SRCDIR}/../../libs/darwin/include
-#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../../libs/darwin/lib -lpython3.13
+#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../../libs/darwin/lib -lpython3.13 -Wl,-rpath,@loader_path/../../libs/darwin/lib
 
 #cgo linux,arm64 CFLAGS: -I${SRCDIR}/../../libs/arm64/include
-#cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../../libs/arm64/lib -lpython3.13
+#cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../../libs/arm64/lib -lpython3.13 -lm -ldl -lutil -Wl,-rpath,\$ORIGIN/../../libs/arm64/lib
 
 #cgo linux,amd64 CFLAGS: -I${SRCDIR}/../../libs/amd64/include
-#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../../libs/amd64/lib -lpython3.13 -lm -ldl -lutil
+#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../../libs/amd64/lib -lpython3.13 -lm -ldl -lutil -Wl,-rpath,\$ORIGIN/../../libs/amd64/lib
 
 #include <Python.h>
 #include <stdlib.h>


### PR DESCRIPTION
## Summary
- build Python with shared libraries for both `x86_64` and `aarch64`
- link against architecture-specific libraries with appropriate rpaths

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897722c65d08329823ef44cf11ba99a